### PR TITLE
社交链接支持自定义

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -13,7 +13,6 @@ export const metadata: Metadata = {
 
 export default function BlogPage() {
   const blogs = allBlogs.sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
-  console.log(blogs);
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,11 +10,16 @@ export default function Home() {
     .sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   const socialLinks = [
-    { name: "赞赏", href: config.social?.buyMeACoffee },
-    { name: "X", href: config.social?.x },
-    { name: "小红书", href: config.social?.xiaohongshu },
-    { name: "微信公众号", href: config.social?.wechat },
-  ].filter(link => !!link.href);
+    { name: "赞赏", key: "buyMeACoffee" },
+    { name: "X", key: "x" },
+    { name: "小红书", key: "xiaohongshu" },
+    { name: "微信公众号", key: "wechat" },
+  ]
+    .map(item => ({
+      name: item.name,
+      href: config.social && config.social[item.key as keyof typeof config.social]
+    }))
+    .filter(link => !!link.href);
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,13 @@ export default function Home() {
     .filter((blog: any) => blog.featured === true)
     .sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
+  const socialLinks = [
+    { name: "赞赏", href: config.social?.buyMeACoffee },
+    { name: "X", href: config.social?.x },
+    { name: "小红书", href: config.social?.xiaohongshu },
+    { name: "微信公众号", href: config.social?.wechat },
+  ].filter(link => !!link.href);
+
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
       {/* 个人介绍部分 */}
@@ -16,16 +23,19 @@ export default function Home() {
         <h1 className="text-4xl font-bold">{config.site.title}</h1>
         <p className="text-md text-gray-600">{config.author.bio}</p>
         
-        {/* 社交链接 */}
-        <div className="flex space-x-2 text-gray-600">
-          <Link href={config.social.buyMeACoffee} className="underline underline-offset-4">赞赏</Link>
-          <span>·</span>
-          <Link href={config.social.x} className="underline underline-offset-4">X</Link>
-          <span>·</span>
-          <Link href={config.social.xiaohongshu} className="underline underline-offset-4">小红书</Link>
-          <span>·</span>
-          <Link href={config.social.wechat} className="underline underline-offset-4">微信公众号</Link>
-        </div>
+        {/* 社交链接 - 仅当有链接时才显示 */}
+        {socialLinks.length > 0 && (
+          <div className="flex space-x-2 text-gray-600">
+            {socialLinks.map((link, index) => (
+              <div key={link.name} className="flex items-center">
+                {index > 0 && <span className="mx-1">·</span>}
+                <Link href={link.href} className="underline underline-offset-4">
+                  {link.name}
+                </Link>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="space-y-4">

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -16,12 +16,17 @@ export function Header() {
   const pathname = usePathname();
   const isBlogPage = pathname.includes("/blog/");
 
-  // Create social links array and filter out undefined links
   const socialLinks = [
-    { title: "Github", href: config.social?.github, icon: <GithubIcon /> },
-    { title: "X", href: config.social?.x, icon: <XIcon /> },
-    { title: "Xiaohongshu", href: config.social?.xiaohongshu, icon: <XiaohongshuIcon /> },
-  ].filter(link => !!link.href);
+    { title: "Github", key: "github", icon: <GithubIcon /> },
+    { title: "X", key: "x", icon: <XIcon /> },
+    { title: "Xiaohongshu", key: "xiaohongshu", icon: <XiaohongshuIcon /> },
+  ]
+    .map(item => ({
+      title: item.title,
+      href: config.social && config.social[item.key as keyof typeof config.social],
+      icon: item.icon
+    }))
+    .filter(link => !!link.href);
 
   return (
     <header className="pt-4">

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -16,6 +16,13 @@ export function Header() {
   const pathname = usePathname();
   const isBlogPage = pathname.includes("/blog/");
 
+  // Create social links array and filter out undefined links
+  const socialLinks = [
+    { title: "Github", href: config.social?.github, icon: <GithubIcon /> },
+    { title: "X", href: config.social?.x, icon: <XIcon /> },
+    { title: "Xiaohongshu", href: config.social?.xiaohongshu, icon: <XiaohongshuIcon /> },
+  ].filter(link => !!link.href);
+
   return (
     <header className="pt-4">
       <motion.div
@@ -39,15 +46,11 @@ export function Header() {
 
         {/* Right side buttons */}
         <div className="flex items-center space-x-2 md:space-x-8 mr-4">
-          <Link href={config.social.github} title="Github">
-            <GithubIcon />
-          </Link>
-          <Link href={config.social.x} title="X">
-            <XIcon />
-          </Link>
-          <Link href={config.social.xiaohongshu} title="Xiaohongshu">
-            <XiaohongshuIcon />
-          </Link>
+          {socialLinks.map((link) => (
+            <Link key={link.title} href={link.href} title={link.title}>
+              {link.icon}
+            </Link>
+          ))}
         </div>
       </motion.div>
     </header >


### PR DESCRIPTION
社交链接 `config.social` 中的字段支持自定义，不需要的可以注释掉，注释掉的就不会在页面上展示。

```typescript
config = {
  social: {
    github: "https://github.com/xxx",
    // x: "https://x.com/xxx",
    // xiaohongshu: "https://www.xiaohongshu.com/user/profile/xxx",
    wechat: "https://storage.xxx.com/images/wechat-official-account.png",
    buyMeACoffee: "https://www.buymeacoffee.com/xxx",
  },
};
```

另外，删除一处 console.log 打印，防止 dev 时终端输出内容过多