### PR TITLE
添加分类/标签模块，支持在Cloudflare pages部署

### DIFF
--- a/content-collections.ts
+++ b/content-collections.ts
@@ -11,8 +11,14 @@ const blogs = defineCollection({
     featured: z.boolean().optional().default(false),
     summary: z.string().optional(),
     keywords: z.array(z.string()).optional(),
+    // 英文分类，用于路由
     category: z.string().optional(),
+    // 中文分类显示，用于界面显示
+    categoryDisplay: z.string().optional(),
+    // 英文标签，用于路由
     tags: z.array(z.string()).optional().default([]),
+    // 中文标签显示，用于界面显示
+    tagsDisplay: z.array(z.string()).optional().default([]),
   }),
   transform: async (document) => {
     return {

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -11,6 +11,8 @@ const blogs = defineCollection({
     featured: z.boolean().optional().default(false),
     summary: z.string().optional(),
     keywords: z.array(z.string()).optional(),
+    category: z.string().optional(),
+    tags: z.array(z.string()).optional().default([]),
   }),
   transform: async (document) => {
     return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^15.2.4",
-        "@next/third-parties": "^15.2.4",
         "@radix-ui/react-collapsible": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-navigation-menu": "^1.2.5",
@@ -1405,18 +1404,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@next/third-parties": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.2.4.tgz",
-      "integrity": "sha512-a8GlPnMmPymxyLOiSnh5InUsG/hw7wjU3munGoHNB+oLCPruAeoplBa9Uf/xE83WMyutyK4cbi5Ixu4uyh96Mw==",
-      "dependencies": {
-        "third-party-capital": "1.0.20"
-      },
-      "peerDependencies": {
-        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
-        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8947,11 +8934,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/third-party-capital": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
-      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA=="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.12",

--- a/src/app/blog/[...slug]/page.tsx
+++ b/src/app/blog/[...slug]/page.tsx
@@ -146,7 +146,7 @@ export default async function BlogPage(props: BlogsPageProps) {
                 <span className="text-sm text-blue-600">分类:</span>
                 <Link href={`/category/${encodeURIComponent(blog.category)}`}>
                   <span className="px-3 py-1 text-sm font-medium bg-blue-100 text-blue-800 rounded-md hover:bg-blue-200 transition-colors">
-                    {blog.category}
+                    {blog.categoryDisplay || blog.category}
                   </span>
                 </Link>
               </div>
@@ -159,10 +159,10 @@ export default async function BlogPage(props: BlogsPageProps) {
                   <span className="text-sm text-gray-600">标签:</span>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {blog.tags.map((tag: string) => (
+                  {blog.tags.map((tag: string, index: number) => (
                     <Link key={tag} href={`/tag/${encodeURIComponent(tag)}`}>
                       <span className="px-3 py-1 text-sm font-medium bg-gray-100 text-gray-800 rounded-md hover:bg-gray-200 transition-colors">
-                        {tag}
+                        {blog.tagsDisplay && blog.tagsDisplay[index] ? blog.tagsDisplay[index] : tag}
                       </span>
                     </Link>
                   ))}

--- a/src/app/blog/[...slug]/page.tsx
+++ b/src/app/blog/[...slug]/page.tsx
@@ -123,10 +123,10 @@ export default async function BlogPage(props: BlogsPageProps) {
     .slice(0, 5); // 只取前5篇
 
   return (
-    <main className="relative py-6 max-w-full md:max-w-6xl mx-auto lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
-      <div className="max-w-4xl mx-auto w-full px-6">
+    <main className="relative py-6 w-full md:max-w-6xl mx-auto lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
+      <div className="w-full mx-auto px-4 sm:px-6 overflow-hidden">
         <div className="my-8">
-          <h1 className="text-[32px] font-bold">{blog.title}</h1>
+          <h1 className="text-2xl md:text-3xl lg:text-[32px] font-bold break-words">{blog.title}</h1>
         </div>
 
         <div className="my-4 space-y-3">
@@ -172,7 +172,7 @@ export default async function BlogPage(props: BlogsPageProps) {
           </div>
         </div>
 
-        <div className="">
+        <div className="overflow-hidden">
           <MDXRemote source={blog.content} components={components} options={options} />
         </div>
 

--- a/src/app/blog/[...slug]/page.tsx
+++ b/src/app/blog/[...slug]/page.tsx
@@ -1,7 +1,8 @@
 import { allBlogs } from "content-collections"
 import type { Metadata } from "next"
-import { absoluteUrl, formatDate } from "@/lib/utils"
+import { absoluteUrl } from "@/lib/utils"
 import { notFound } from "next/navigation"
+import Link from "next/link"
 import { getTableOfContents } from "@/lib/toc"
 import { DashboardTableOfContents } from "@/components/toc"
 import { MDXRemote } from 'next-mdx-remote-client/rsc'
@@ -17,6 +18,8 @@ import GiscusComments from "@/components/giscus-comments"
 import { GoToTop } from "@/components/go-to-top"
 import 'katex/dist/katex.min.css';
 import { config } from "@/lib/config";
+import { Bookmark, Tag, Clock, FileText } from "lucide-react";
+import { TagCloud } from "@/components/tag-cloud";
 
 type BlogsPageProps = {
   params: Promise<{slug: string[]}>
@@ -98,6 +101,27 @@ export default async function BlogPage(props: BlogsPageProps) {
   }
 
   const toc = await getTableOfContents(blog.content)
+  
+  // 获取相关文章
+  const relatedArticles = allBlogs
+    .filter((article: any) => {
+      // 排除当前文章
+      if (article.slug === blog.slug) return false;
+      
+      // 相同分类
+      if (article.category === blog.category) return true;
+      
+      // 共同标签
+      if (blog.tags && article.tags) {
+        for (const tag of blog.tags) {
+          if (article.tags.includes(tag)) return true;
+        }
+      }
+      
+      return false;
+    })
+    .sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 5); // 只取前5篇
 
   return (
     <main className="relative py-6 max-w-full md:max-w-6xl mx-auto lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
@@ -106,10 +130,47 @@ export default async function BlogPage(props: BlogsPageProps) {
           <h1 className="text-[32px] font-bold">{blog.title}</h1>
         </div>
 
-        <div className="my-4">
+        <div className="my-4 space-y-3">
           <p className="text-sm">
-            {formatDate(blog.date)} · {count(blog.content)} 字
+            {new Date(blog.date).toLocaleDateString('zh-CN', {
+              year: 'numeric',
+              month: 'numeric', 
+              day: 'numeric'
+            }).replace(/\//g, '年').replace(/\//g, '月') + '日'} · {count(blog.content)} 字
           </p>
+          
+          {/* 分类和标签 */}
+          <div className="flex flex-wrap items-center gap-4">
+            {blog.category && (
+              <div className="flex items-center gap-1">
+                <Bookmark className="h-4 w-4 text-blue-600" />
+                <span className="text-sm text-blue-600">分类:</span>
+                <Link href={`/category/${encodeURIComponent(blog.category)}`}>
+                  <span className="px-3 py-1 text-sm font-medium bg-blue-100 text-blue-800 rounded-md hover:bg-blue-200 transition-colors">
+                    {blog.category}
+                  </span>
+                </Link>
+              </div>
+            )}
+            
+            {blog.tags && blog.tags.length > 0 && (
+              <div className="flex items-center gap-2">
+                <div className="flex items-center gap-1">
+                  <Tag className="h-4 w-4 text-gray-600" />
+                  <span className="text-sm text-gray-600">标签:</span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {blog.tags.map((tag: string) => (
+                    <Link key={tag} href={`/tag/${encodeURIComponent(tag)}`}>
+                      <span className="px-3 py-1 text-sm font-medium bg-gray-100 text-gray-800 rounded-md hover:bg-gray-200 transition-colors">
+                        {tag}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="">
@@ -120,8 +181,42 @@ export default async function BlogPage(props: BlogsPageProps) {
       </div>
       <div className="hidden text-sm xl:block">
         <div className="sticky top-16 -mt-6 h-[calc(100vh-3.5rem)]">
-          <div className="h-full overflow-auto pb-10 flex flex-col justify-between mt-16 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:'none'] [scrollbar-width:'none']">
-            <DashboardTableOfContents toc={toc} />
+          <div className="h-full overflow-auto pb-10 flex flex-col gap-8 mt-16 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:'none'] [scrollbar-width:'none']">
+            {/* 目录 */}
+            <div>
+              <h3 className="mb-4 text-lg font-semibold">目录</h3>
+              <DashboardTableOfContents toc={toc} />
+            </div>
+            
+            {/* 文章标签部分已移除 */}
+            
+            {/* 相关文章 */}
+            {relatedArticles.length > 0 && (
+              <div className="bg-gray-50 p-4 rounded-lg">
+                <h3 className="text-base font-semibold mb-3 flex items-center">
+                  <FileText className="h-4 w-4 mr-2 text-gray-600" />
+                  相关文章
+                </h3>
+                <div className="space-y-3">
+                  {relatedArticles.map((article: any) => (
+                    <div key={article.slug} className="border-b border-gray-100 pb-2 last:border-0">
+                      <Link href={`/blog/${article.slug}`} className="hover:text-blue-600 transition-colors">
+                        <div className="text-sm font-medium line-clamp-2">{article.title}</div>
+                        <div className="flex items-center text-xs text-gray-500 mt-1">
+                          <Clock className="h-3 w-3 mr-1" />
+                          {new Date(article.date).toLocaleDateString('zh-CN', {
+                            year: 'numeric',
+                            month: 'numeric', 
+                            day: 'numeric'
+                          }).replace(/\//g, '年').replace(/\//g, '月') + '日'}
+                        </div>
+                      </Link>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            
             <GoToTop />
           </div>
         </div>

--- a/src/app/blog/[...slug]/page.tsx
+++ b/src/app/blog/[...slug]/page.tsx
@@ -19,7 +19,6 @@ import { GoToTop } from "@/components/go-to-top"
 import 'katex/dist/katex.min.css';
 import { config } from "@/lib/config";
 import { Bookmark, Tag, Clock, FileText } from "lucide-react";
-import { TagCloud } from "@/components/tag-cloud";
 
 type BlogsPageProps = {
   params: Promise<{slug: string[]}>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,7 +3,8 @@ import { allBlogs } from "content-collections";
 import Link from "next/link";
 import count from 'word-count'
 import { config } from "@/lib/config";
-import { formatDate } from "@/lib/utils";
+import { Bookmark, Tag, ChevronRight } from "lucide-react";
+import { TagCloud } from "@/components/tag-cloud";
 
 export const metadata: Metadata = {
   title: `Blogs | ${config.site.title}`,
@@ -14,31 +15,113 @@ export const metadata: Metadata = {
 export default function BlogPage() {
   const blogs = allBlogs.sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
+  // 获取所有分类
+  const categories = new Set<string>();
+  allBlogs.forEach((blog: any) => {
+    if (blog.category) {
+      categories.add(blog.category);
+    }
+  });
+
   return (
-    <div className="max-w-3xl mx-auto px-4 py-8">
-      <div className="space-y-8">
-        {blogs.map((blog: any) => (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <div className="flex flex-col md:flex-row gap-8">
+        {/* 主内容区 */}
+        <div className="md:w-2/3 space-y-8">
+          {blogs.map((blog: any) => (
           <article 
             key={blog.slug} 
             className=""
           >
-            <Link href={`/blog/${blog.slug}`}>
-              <div className="flex flex-col space-y-2">
-                <div className="flex items-center justify-between">
+            <div className="flex flex-col space-y-2">
+              <Link href={`/blog/${blog.slug}`}>
+                <div>
                   <h2 className="text-xl font-semibold underline underline-offset-4">
                     {blog.title}
                   </h2>
-                  <span className="text-sm text-gray-500">
-                    {formatDate(blog.date)} · {count(blog.content)} 字
-                  </span>
+                  <div className="text-sm text-gray-500 mt-1">
+                    {new Date(blog.date).toLocaleDateString('zh-CN', {
+                      year: 'numeric',
+                      month: 'numeric', 
+                      day: 'numeric'
+                    }).replace(/\//g, '年').replace(/\//g, '月') + '日'} · {count(blog.content)} 字
+                  </div>
                 </div>
-                <p className="text-gray-600 line-clamp-2">
+                <p className="text-gray-600 line-clamp-2 mt-2">
                   {blog.summary}
                 </p>
-              </div>
-            </Link>
+              </Link>
+              
+              {blog.category && (
+                <div className="flex items-center gap-2 mt-2">
+                  <div className="flex items-center gap-1">
+                    <Bookmark className="h-3 w-3 text-blue-600" />
+                    <Link href={`/category/${encodeURIComponent(blog.category)}`}>
+                      <span className="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-md hover:bg-blue-200 transition-colors">
+                        {blog.category}
+                      </span>
+                    </Link>
+                  </div>
+                  {blog.tags && blog.tags.length > 0 && (
+                    <div className="flex items-center gap-1">
+                      <Tag className="h-3 w-3 text-gray-500" />
+                      <div className="flex flex-wrap gap-1">
+                        {blog.tags.map((tag: string) => (
+                          <Link key={tag} href={`/tag/${encodeURIComponent(tag)}`}>
+                            <span className="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-md hover:bg-gray-200 transition-colors">
+                              {tag}
+                            </span>
+                          </Link>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
           </article>
         ))}
+        </div>
+
+        {/* 侧边栏 */}
+        <div className="md:w-1/4 space-y-8">
+          {/* 分类列表 - 根据配置显示 */}
+          {config.article_category.sidebar && (
+            <div className="bg-gray-20 p-6 rounded-lg shadow-sm">
+              <h3 className="text-lg font-semibold mb-4 flex items-center">
+                <Bookmark className="h-5 w-5 mr-2 text-gray-600" />
+                分类
+              </h3>
+              <div className="space-y-2">
+                {Array.from(categories).map((category) => (
+                  <Link 
+                    key={category} 
+                    href={`/category/${encodeURIComponent(category)}`}
+                    className="block py-1 px-2 hover:bg-gray-100 rounded transition-colors text-sm"
+                  >
+                    {category}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* 标签云 - 根据配置显示 */}
+          {config.article_tag.sidebar && (
+            <div className="bg-gray-20 p-6 rounded-lg shadow-sm">
+              <h3 className="text-lg font-semibold mb-4 flex items-center">
+                <Tag className="h-5 w-5 mr-2 text-gray-600" />
+                标签
+              </h3>
+              <TagCloud showCount={true} useFixedSize={true} />
+              <div className="mt-4 text-right">
+                <Link href="/tag" className="text-sm text-blue-600 hover:underline inline-flex items-center">
+                  查看全部标签 <ChevronRight className="h-3 w-3 ml-1" />
+                </Link>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -17,9 +17,16 @@ export default function BlogPage() {
 
   // 获取所有分类
   const categories = new Set<string>();
+  // 分类显示名称映射
+  const categoryDisplayMap: Record<string, string> = {};
+  
   allBlogs.forEach((blog: any) => {
     if (blog.category) {
       categories.add(blog.category);
+      // 记录分类显示名称
+      if (blog.categoryDisplay) {
+        categoryDisplayMap[blog.category] = blog.categoryDisplay;
+      }
     }
   });
 
@@ -58,7 +65,7 @@ export default function BlogPage() {
                     <Bookmark className="h-3 w-3 text-blue-600" />
                     <Link href={`/category/${encodeURIComponent(blog.category)}`}>
                       <span className="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-md hover:bg-blue-200 transition-colors">
-                        {blog.category}
+                        {blog.categoryDisplay || blog.category}
                       </span>
                     </Link>
                   </div>
@@ -66,10 +73,10 @@ export default function BlogPage() {
                     <div className="flex items-center gap-1">
                       <Tag className="h-3 w-3 text-gray-500" />
                       <div className="flex flex-wrap gap-1">
-                        {blog.tags.map((tag: string) => (
+                        {blog.tags.map((tag: string, index: number) => (
                           <Link key={tag} href={`/tag/${encodeURIComponent(tag)}`}>
                             <span className="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-md hover:bg-gray-200 transition-colors">
-                              {tag}
+                              {blog.tagsDisplay && blog.tagsDisplay[index] ? blog.tagsDisplay[index] : tag}
                             </span>
                           </Link>
                         ))}
@@ -99,7 +106,7 @@ export default function BlogPage() {
                     href={`/category/${encodeURIComponent(category)}`}
                     className="block py-1 px-2 hover:bg-gray-100 rounded transition-colors text-sm"
                   >
-                    {category}
+                    {categoryDisplayMap[category] || category}
                   </Link>
                 ))}
               </div>

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { allBlogs } from "content-collections";
 import Link from "next/link";
 import count from 'word-count'
 import { config } from "@/lib/config";
-import { Tag, Bookmark, ChevronRight } from "lucide-react";
+import { Tag, ChevronRight } from "lucide-react";
 import { notFound } from "next/navigation";
 import { TagCloud } from "@/components/tag-cloud";
 

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { notFound } from "next/navigation";
 import { TagCloud } from "@/components/tag-cloud";
 
 type CategoryPageProps = {
-  params: { slug: string }
+  params: Promise<{ slug: string }>
 }
 
 export async function generateMetadata({ params }: CategoryPageProps): Promise<Metadata> {

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -68,10 +68,10 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
   });
 
   return (
-    <div className="max-w-6xl mx-auto px-4 py-8">
+    <div className="w-full max-w-6xl mx-auto px-4 py-8 overflow-hidden">
       <div className="flex flex-col md:flex-row gap-8">
         <div className="md:w-2/3">
-          <h1 className="text-3xl font-bold mb-8">分类: {categoryDisplay}</h1>
+          <h1 className="text-2xl md:text-3xl font-bold mb-8 break-words">分类: {categoryDisplay}</h1>
           <p className="text-gray-600 mb-6">该分类下共有 {filteredBlogs.length} 篇文章</p>
           
           <div className="space-y-8">

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -1,0 +1,142 @@
+import { type Metadata } from "next";
+import { allBlogs } from "content-collections";
+import Link from "next/link";
+import count from 'word-count'
+import { config } from "@/lib/config";
+import { Tag, Bookmark, ChevronRight } from "lucide-react";
+import { notFound } from "next/navigation";
+import { TagCloud } from "@/components/tag-cloud";
+
+type CategoryPageProps = {
+  params: { slug: string }
+}
+
+export async function generateMetadata({ params }: CategoryPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const decodedCategory = decodeURIComponent(slug);
+  
+  return {
+    title: `${decodedCategory} | ${config.site.title}`,
+    description: `${decodedCategory}分类下的所有文章 - ${config.site.title}`,
+  };
+}
+
+export async function generateStaticParams() {
+  const categories = new Set<string>();
+  
+  allBlogs.forEach((blog: any) => {
+    if (blog.category) {
+      categories.add(blog.category);
+    }
+  });
+  
+  return Array.from(categories).map(category => ({
+    slug: category,
+  }));
+}
+
+export default async function CategoryPage({ params }: CategoryPageProps) {
+  const { slug } = await params;
+  const decodedCategory = decodeURIComponent(slug);
+  
+  const filteredBlogs = allBlogs
+    .filter((blog: any) => blog.category === decodedCategory)
+    .sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  
+  if (filteredBlogs.length === 0) {
+    notFound();
+  }
+  
+  // 获取该分类下的所有标签
+  const categoryTags = new Set<string>();
+  filteredBlogs.forEach((blog: any) => {
+    if (blog.tags && Array.isArray(blog.tags)) {
+      blog.tags.forEach((tag: string) => categoryTags.add(tag));
+    }
+  });
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <div className="flex flex-col md:flex-row gap-8">
+        <div className="md:w-2/3">
+          <h1 className="text-3xl font-bold mb-8">分类: {decodedCategory}</h1>
+          <p className="text-gray-600 mb-6">该分类下共有 {filteredBlogs.length} 篇文章</p>
+          
+          <div className="space-y-8">
+            {filteredBlogs.map((blog: any) => (
+          <article 
+            key={blog.slug} 
+            className=""
+          >
+            <div className="flex flex-col space-y-2">
+              <Link href={`/blog/${blog.slug}`}>
+                <div>
+                  <h2 className="text-xl font-semibold underline underline-offset-4">
+                    {blog.title}
+                  </h2>
+                  <div className="text-sm text-gray-500 mt-1">
+                    {new Date(blog.date).toLocaleDateString('zh-CN', {
+                      year: 'numeric',
+                      month: 'numeric', 
+                      day: 'numeric'
+                    }).replace(/\//g, '年').replace(/\//g, '月') + '日'} · {count(blog.content)} 字
+                  </div>
+                </div>
+                <p className="text-gray-600 line-clamp-2 mt-2">
+                  {blog.summary}
+                </p>
+              </Link>
+              
+              {blog.tags && blog.tags.length > 0 && (
+                <div className="flex items-center gap-2 mt-2">
+                  <div className="flex items-center gap-1">
+                    <Tag className="h-3 w-3 text-gray-500" />
+                    <div className="flex flex-wrap gap-1">
+                      {blog.tags.map((tag: string) => (
+                        <Link key={tag} href={`/tag/${encodeURIComponent(tag)}`}>
+                          <span className="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-md hover:bg-gray-200 transition-colors">
+                            {tag}
+                          </span>
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </article>
+            ))}
+          </div>
+        </div>
+        
+        {/* 侧边栏 */}
+        <div className="md:w-1/4 space-y-8">
+          {/* 分类下的标签 - 根据配置显示 */}
+          {config.article_tag.sidebar && categoryTags.size > 0 && (
+            <div className="bg-gray-40 p-6 rounded-lg shadow-sm">
+              <h3 className="text-lg font-semibold mb-4 flex items-center">
+                <Tag className="h-5 w-5 mr-2 text-gray-600" />
+                {decodedCategory} 分类下的标签
+              </h3>
+              <div>
+                {/* 使用 TagCloud 组件显示所有标签 */}
+                <TagCloud 
+                  showCount={true} 
+                  useFixedSize={true}
+                  customTags={Array.from(categoryTags).map(tag => ({ tag, count: filteredBlogs.filter(blog => 
+                    blog.tags && Array.isArray(blog.tags) && blog.tags.includes(tag)
+                  ).length }))} 
+                />
+              </div>
+              <div className="mt-4 text-right">
+                <Link href="/tag" className="text-sm text-blue-600 hover:underline inline-flex items-center">
+                  查看全部标签 <ChevronRight className="h-3 w-3 ml-1" />
+                </Link>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/category/[slug]/page.tsx
+++ b/src/app/category/[slug]/page.tsx
@@ -47,11 +47,23 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
     notFound();
   }
   
+  // 获取分类的中文显示名称
+  const categoryDisplay = filteredBlogs[0].categoryDisplay || decodedCategory;
+  
   // 获取该分类下的所有标签
   const categoryTags = new Set<string>();
+  // 标签显示名称映射
+  const tagDisplayMap: Record<string, string> = {};
+  
   filteredBlogs.forEach((blog: any) => {
     if (blog.tags && Array.isArray(blog.tags)) {
-      blog.tags.forEach((tag: string) => categoryTags.add(tag));
+      blog.tags.forEach((tag: string, index: number) => {
+        categoryTags.add(tag);
+        // 记录标签显示名称
+        if (blog.tagsDisplay && blog.tagsDisplay[index]) {
+          tagDisplayMap[tag] = blog.tagsDisplay[index];
+        }
+      });
     }
   });
 
@@ -59,7 +71,7 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
     <div className="max-w-6xl mx-auto px-4 py-8">
       <div className="flex flex-col md:flex-row gap-8">
         <div className="md:w-2/3">
-          <h1 className="text-3xl font-bold mb-8">分类: {decodedCategory}</h1>
+          <h1 className="text-3xl font-bold mb-8">分类: {categoryDisplay}</h1>
           <p className="text-gray-600 mb-6">该分类下共有 {filteredBlogs.length} 篇文章</p>
           
           <div className="space-y-8">
@@ -92,10 +104,10 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
                   <div className="flex items-center gap-1">
                     <Tag className="h-3 w-3 text-gray-500" />
                     <div className="flex flex-wrap gap-1">
-                      {blog.tags.map((tag: string) => (
+                      {blog.tags.map((tag: string, index: number) => (
                         <Link key={tag} href={`/tag/${encodeURIComponent(tag)}`}>
                           <span className="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-800 rounded-md hover:bg-gray-200 transition-colors">
-                            {tag}
+                            {blog.tagsDisplay && blog.tagsDisplay[index] ? blog.tagsDisplay[index] : tag}
                           </span>
                         </Link>
                       ))}
@@ -116,16 +128,20 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
             <div className="bg-gray-40 p-6 rounded-lg shadow-sm">
               <h3 className="text-lg font-semibold mb-4 flex items-center">
                 <Tag className="h-5 w-5 mr-2 text-gray-600" />
-                {decodedCategory} 分类下的标签
+                {categoryDisplay} 分类下的标签
               </h3>
               <div>
                 {/* 使用 TagCloud 组件显示所有标签 */}
                 <TagCloud 
                   showCount={true} 
                   useFixedSize={true}
-                  customTags={Array.from(categoryTags).map(tag => ({ tag, count: filteredBlogs.filter(blog => 
-                    blog.tags && Array.isArray(blog.tags) && blog.tags.includes(tag)
-                  ).length }))} 
+                  customTags={Array.from(categoryTags).map(tag => ({ 
+                    tag, 
+                    count: filteredBlogs.filter(blog => 
+                      blog.tags && Array.isArray(blog.tags) && blog.tags.includes(tag)
+                    ).length,
+                    displayName: tagDisplayMap[tag] || tag
+                  }))} 
                 />
               </div>
               <div className="mt-4 text-right">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,7 +59,7 @@ export default function RootLayout({
         <link rel="alternate" type="application/json" title="JSON" href="/feed.json" />
         <link rel="icon" href="/favicon.ico" sizes="any" />
       </head>
-      <body className="min-w-md overflow-x-hidden">
+      <body className="overflow-x-hidden">
         <Header />
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,14 +9,14 @@ export default function Home() {
     .sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-8">
+    <div className="w-full max-w-3xl mx-auto px-4 py-8 overflow-hidden">
       {/* 个人介绍部分 */}
       <div className="mb-16 space-y-4">
-        <h1 className="text-4xl font-bold">{config.site.title}</h1>
-        <p className="text-md text-gray-600">{config.author.bio}</p>
+        <h1 className="text-3xl md:text-4xl font-bold break-words">{config.site.title}</h1>
+        <p className="text-md text-gray-600 break-words">{config.author.bio}</p>
         
         {/* 社交链接 */}
-        <div className="flex space-x-2 text-gray-600">
+        <div className="flex flex-wrap gap-2 text-gray-600">
           <Link href={config.social.buyMeACoffee} className="underline underline-offset-4">赞赏</Link>
           <span>·</span>
           <Link href={config.social.x} className="underline underline-offset-4">X</Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,24 +2,11 @@ import { allBlogs } from "content-collections";
 import Link from "next/link";
 import count from 'word-count'
 import { config } from "@/lib/config";
-import { formatDate } from "@/lib/utils";
 
 export default function Home() {
   const blogs = allBlogs
     .filter((blog: any) => blog.featured === true)
     .sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
-
-  const socialLinks = [
-    { name: "赞赏", key: "buyMeACoffee" },
-    { name: "X", key: "x" },
-    { name: "小红书", key: "xiaohongshu" },
-    { name: "微信公众号", key: "wechat" },
-  ]
-    .map(item => ({
-      name: item.name,
-      href: config.social && config.social[item.key as keyof typeof config.social]
-    }))
-    .filter(link => !!link.href);
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
@@ -28,19 +15,16 @@ export default function Home() {
         <h1 className="text-4xl font-bold">{config.site.title}</h1>
         <p className="text-md text-gray-600">{config.author.bio}</p>
         
-        {/* 社交链接 - 仅当有链接时才显示 */}
-        {socialLinks.length > 0 && (
-          <div className="flex space-x-2 text-gray-600">
-            {socialLinks.map((link, index) => (
-              <div key={link.name} className="flex items-center">
-                {index > 0 && <span className="mx-1">·</span>}
-                <Link href={link.href} className="underline underline-offset-4">
-                  {link.name}
-                </Link>
-              </div>
-            ))}
-          </div>
-        )}
+        {/* 社交链接 */}
+        <div className="flex space-x-2 text-gray-600">
+          <Link href={config.social.buyMeACoffee} className="underline underline-offset-4">赞赏</Link>
+          <span>·</span>
+          <Link href={config.social.x} className="underline underline-offset-4">X</Link>
+          <span>·</span>
+          <Link href={config.social.xiaohongshu} className="underline underline-offset-4">小红书</Link>
+          <span>·</span>
+          <Link href={config.social.wechat} className="underline underline-offset-4">微信公众号</Link>
+        </div>
       </div>
 
       <div className="space-y-4">
@@ -55,7 +39,11 @@ export default function Home() {
                       {blog.title}
                     </h2>
                     <span className="text-sm text-gray-500">
-                      {formatDate(blog.date)} · {count(blog.content)} 字
+                      {new Date(blog.date).toLocaleDateString('zh-CN', {
+                        year: 'numeric',
+                        month: 'numeric',
+                        day: 'numeric'
+                      }).replace(/\//g, '年').replace(/\//g, '月') + '日'} · {count(blog.content)} 字
                     </span>
                   </div>
                   <p className="text-gray-600 line-clamp-2">

--- a/src/app/tag/[slug]/page.tsx
+++ b/src/app/tag/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { allBlogs } from "content-collections";
 import Link from "next/link";
 import count from 'word-count'
 import { config } from "@/lib/config";
-import { Bookmark, Tag } from "lucide-react";
+import { Bookmark } from "lucide-react";
 import { notFound } from "next/navigation";
 
 type TagPageProps = {

--- a/src/app/tag/[slug]/page.tsx
+++ b/src/app/tag/[slug]/page.tsx
@@ -47,10 +47,24 @@ export default async function TagPage({ params }: TagPageProps) {
   if (filteredBlogs.length === 0) {
     notFound();
   }
+  
+  // 获取标签的中文显示名称
+  let tagDisplay = decodedTag;
+  
+  // 循环查找标签的中文显示名称
+  for (const blog of filteredBlogs) {
+    if (blog.tags && blog.tagsDisplay) {
+      const tagIndex = blog.tags.indexOf(decodedTag);
+      if (tagIndex !== -1 && blog.tagsDisplay[tagIndex]) {
+        tagDisplay = blog.tagsDisplay[tagIndex];
+        break;
+      }
+    }
+  }
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">标签: {decodedTag}</h1>
+      <h1 className="text-3xl font-bold mb-8">标签: {tagDisplay}</h1>
       <p className="text-gray-600 mb-6">该标签下共有 {filteredBlogs.length} 篇文章</p>
       
       <div className="space-y-8">
@@ -84,7 +98,7 @@ export default async function TagPage({ params }: TagPageProps) {
                     <Bookmark className="h-3 w-3 text-blue-600" />
                     <Link href={`/category/${encodeURIComponent(blog.category)}`}>
                       <span className="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-md hover:bg-blue-200 transition-colors">
-                        {blog.category}
+                        {blog.categoryDisplay || blog.category}
                       </span>
                     </Link>
                   </div>

--- a/src/app/tag/[slug]/page.tsx
+++ b/src/app/tag/[slug]/page.tsx
@@ -1,0 +1,99 @@
+import { type Metadata } from "next";
+import { allBlogs } from "content-collections";
+import Link from "next/link";
+import count from 'word-count'
+import { config } from "@/lib/config";
+import { Bookmark, Tag } from "lucide-react";
+import { notFound } from "next/navigation";
+
+type TagPageProps = {
+  params: { slug: string }
+}
+
+export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const decodedTag = decodeURIComponent(slug);
+  
+  return {
+    title: `标签: ${decodedTag} | ${config.site.title}`,
+    description: `标签为 ${decodedTag} 的所有文章 - ${config.site.title}`,
+  };
+}
+
+export async function generateStaticParams() {
+  const tags = new Set<string>();
+  
+  allBlogs.forEach((blog: any) => {
+    if (blog.tags && Array.isArray(blog.tags)) {
+      blog.tags.forEach((tag: string) => {
+        tags.add(tag);
+      });
+    }
+  });
+  
+  return Array.from(tags).map(tag => ({
+    slug: tag,
+  }));
+}
+
+export default async function TagPage({ params }: TagPageProps) {
+  const { slug } = await params;
+  const decodedTag = decodeURIComponent(slug);
+  
+  const filteredBlogs = allBlogs
+    .filter((blog: any) => blog.tags && Array.isArray(blog.tags) && blog.tags.includes(decodedTag))
+    .sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  
+  if (filteredBlogs.length === 0) {
+    notFound();
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-8">标签: {decodedTag}</h1>
+      <p className="text-gray-600 mb-6">该标签下共有 {filteredBlogs.length} 篇文章</p>
+      
+      <div className="space-y-8">
+        {filteredBlogs.map((blog: any) => (
+          <article 
+            key={blog.slug} 
+            className=""
+          >
+            <div className="flex flex-col space-y-2">
+              <Link href={`/blog/${blog.slug}`}>
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xl font-semibold underline underline-offset-4">
+                    {blog.title}
+                  </h2>
+                  <span className="text-sm text-gray-500">
+                  {new Date(blog.date).toLocaleDateString('zh-CN', {
+                    year: 'numeric',
+                    month: 'numeric', 
+                    day: 'numeric'
+                  }).replace(/\//g, '年').replace(/\//g, '月') + '日'} · {count(blog.content)} 字
+                  </span>
+                </div>
+                <p className="text-gray-600 line-clamp-2 mt-2">
+                  {blog.summary}
+                </p>
+              </Link>
+              
+              {blog.category && (
+                <div className="flex items-center gap-2 mt-2">
+                  <div className="flex items-center gap-1">
+                    <Bookmark className="h-3 w-3 text-blue-600" />
+                    <Link href={`/category/${encodeURIComponent(blog.category)}`}>
+                      <span className="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-md hover:bg-blue-200 transition-colors">
+                        {blog.category}
+                      </span>
+                    </Link>
+                  </div>
+                </div>
+              )}
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/tag/[slug]/page.tsx
+++ b/src/app/tag/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { Bookmark } from "lucide-react";
 import { notFound } from "next/navigation";
 
 type TagPageProps = {
-  params: { slug: string }
+  params: Promise<{ slug: string }>
 }
 
 export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {

--- a/src/app/tag/[slug]/page.tsx
+++ b/src/app/tag/[slug]/page.tsx
@@ -63,8 +63,8 @@ export default async function TagPage({ params }: TagPageProps) {
   }
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">标签: {tagDisplay}</h1>
+    <div className="w-full max-w-3xl mx-auto px-4 py-8 overflow-hidden">
+      <h1 className="text-2xl md:text-3xl font-bold mb-8 break-words">标签: {tagDisplay}</h1>
       <p className="text-gray-600 mb-6">该标签下共有 {filteredBlogs.length} 篇文章</p>
       
       <div className="space-y-8">

--- a/src/app/tag/page.tsx
+++ b/src/app/tag/page.tsx
@@ -1,0 +1,27 @@
+import { type Metadata } from "next";
+import { EnhancedTagList } from "@/components/enhanced-tag-list";
+import { config } from "@/lib/config";
+
+export const metadata: Metadata = {
+  title: `所有标签 | ${config.site.title}`,
+  description: `浏览所有文章标签 - ${config.site.title}`,
+};
+
+export default function TagsPage() {
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold">所有标签</h1>
+          <p className="text-gray-600 mt-2">
+            浏览所有文章标签，点击标签可以查看相关文章。标签颜色深浅反映了使用频率。
+          </p>
+        </div>
+        
+        <div className="bg-white rounded-lg shadow-sm p-6">
+          <EnhancedTagList />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/enhanced-tag-list.tsx
+++ b/src/components/enhanced-tag-list.tsx
@@ -11,7 +11,7 @@ type ViewMode = 'grid' | 'list'
 type SortMode = 'frequency' | 'name'
 
 export function EnhancedTagList() {
-  const [tags, setTags] = React.useState<Array<{tag: string, count: number}>>([])
+  const [tags, setTags] = React.useState<Array<{tag: string, count: number, displayName?: string}>>([])
   const [searchQuery, setSearchQuery] = React.useState('')
   const [viewMode, setViewMode] = React.useState<ViewMode>('grid')
   const [sortMode, setSortMode] = React.useState<SortMode>('frequency')
@@ -32,9 +32,10 @@ export function EnhancedTagList() {
   const filteredTags = React.useMemo(() => {
     if (!searchQuery.trim()) return tags
     
-    return tags.filter(tag => 
-      tag.tag.toLowerCase().includes(searchQuery.toLowerCase())
-    )
+    return tags.filter(tag => {
+      const searchTarget = tag.displayName || tag.tag
+      return searchTarget.toLowerCase().includes(searchQuery.toLowerCase())
+    })
   }, [tags, searchQuery])
   
   // 根据排序模式排序标签
@@ -134,42 +135,42 @@ export function EnhancedTagList() {
           没有找到匹配的标签
         </div>
       ) : viewMode === 'grid' ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-          {sortedTags.map(({ tag, count }) => (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+          {sortedTags.map((tagItem) => (
             <Link 
-              key={tag} 
-              href={`/tag/${encodeURIComponent(tag)}`}
+              key={tagItem.tag} 
+              href={`/tag/${encodeURIComponent(tagItem.tag)}`}
               className={cn(
                 "flex items-center justify-between p-3 rounded-md border transition-all hover:shadow-md",
-                getTagColorClass(count)
+                getTagColorClass(tagItem.count)
               )}
             >
-              <span className="font-medium truncate">{tag}</span>
+              <span className="font-medium truncate">{tagItem.displayName || tagItem.tag}</span>
               <span className="text-xs px-2 py-1 rounded-full bg-white bg-opacity-70">
-                {count}
+                {tagItem.count}
               </span>
             </Link>
           ))}
         </div>
       ) : (
         <div className="space-y-2">
-          {sortedTags.map(({ tag, count }) => (
+          {sortedTags.map((tagItem) => (
             <Link 
-              key={tag} 
-              href={`/tag/${encodeURIComponent(tag)}`}
+              key={tagItem.tag} 
+              href={`/tag/${encodeURIComponent(tagItem.tag)}`}
               className="flex items-center justify-between p-3 rounded-md border border-gray-100 hover:bg-gray-50 transition-colors"
             >
               <div className="flex items-center gap-2">
                 <div className={cn(
                   "w-3 h-3 rounded-full",
-                  count > 5 ? "bg-blue-500" : 
-                  count > 3 ? "bg-blue-300" : 
-                  count > 1 ? "bg-blue-200" : "bg-gray-300"
+                  tagItem.count > 5 ? "bg-blue-500" : 
+                  tagItem.count > 3 ? "bg-blue-300" : 
+                  tagItem.count > 1 ? "bg-blue-200" : "bg-gray-300"
                 )} />
-                <span>{tag}</span>
+                <span>{tagItem.displayName || tagItem.tag}</span>
               </div>
               <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-500">{count} 篇文章</span>
+                <span className="text-sm text-gray-500">{tagItem.count} 篇文章</span>
               </div>
             </Link>
           ))}

--- a/src/components/enhanced-tag-list.tsx
+++ b/src/components/enhanced-tag-list.tsx
@@ -1,0 +1,180 @@
+"use client"
+
+import * as React from 'react'
+import Link from 'next/link'
+import { Search, ArrowUpDown, Grid, List } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { getTagsWithFrequency } from './tag-cloud'
+import { Button } from '@/components/ui/button'
+
+type ViewMode = 'grid' | 'list'
+type SortMode = 'frequency' | 'name'
+
+export function EnhancedTagList() {
+  const [tags, setTags] = React.useState<Array<{tag: string, count: number}>>([])
+  const [searchQuery, setSearchQuery] = React.useState('')
+  const [viewMode, setViewMode] = React.useState<ViewMode>('grid')
+  const [sortMode, setSortMode] = React.useState<SortMode>('frequency')
+  const [totalTags, setTotalTags] = React.useState(0)
+  const [totalArticles, setTotalArticles] = React.useState(0)
+  
+  React.useEffect(() => {
+    const allTags = getTagsWithFrequency()
+    setTags(allTags)
+    setTotalTags(allTags.length)
+    
+    // 计算文章总数（可能有重复计算，仅作为参考）
+    const articleCount = allTags.reduce((sum, tag) => sum + tag.count, 0)
+    setTotalArticles(articleCount)
+  }, [])
+  
+  // 根据搜索词过滤标签
+  const filteredTags = React.useMemo(() => {
+    if (!searchQuery.trim()) return tags
+    
+    return tags.filter(tag => 
+      tag.tag.toLowerCase().includes(searchQuery.toLowerCase())
+    )
+  }, [tags, searchQuery])
+  
+  // 根据排序模式排序标签
+  const sortedTags = React.useMemo(() => {
+    if (sortMode === 'frequency') {
+      return [...filteredTags].sort((a, b) => b.count - a.count)
+    } else {
+      return [...filteredTags].sort((a, b) => a.tag.localeCompare(b.tag))
+    }
+  }, [filteredTags, sortMode])
+  
+  // 获取标签的颜色深度，基于使用频率
+  const getTagColorClass = (count: number) => {
+    const max = Math.max(...tags.map(t => t.count))
+    const min = Math.min(...tags.map(t => t.count))
+    
+    if (max === min) return 'bg-blue-100 text-blue-800 border-blue-200'
+    
+    const ratio = (count - min) / (max - min)
+    
+    if (ratio > 0.8) return 'bg-blue-200 text-blue-900 border-blue-300 font-medium'
+    if (ratio > 0.6) return 'bg-blue-100 text-blue-800 border-blue-200'
+    if (ratio > 0.4) return 'bg-gray-200 text-gray-800 border-gray-300'
+    if (ratio > 0.2) return 'bg-gray-100 text-gray-700 border-gray-200'
+    return 'bg-gray-50 text-gray-600 border-gray-100'
+  }
+  
+  return (
+    <div className="space-y-6">
+      {/* 统计信息 */}
+      <div className="flex flex-wrap justify-between items-center gap-4 bg-gray-50 p-4 rounded-lg">
+        <div className="flex items-center gap-4">
+          <div>
+            <div className="text-sm text-gray-500">标签总数</div>
+            <div className="text-2xl font-bold">{totalTags}</div>
+          </div>
+          <div>
+            <div className="text-sm text-gray-500">文章引用</div>
+            <div className="text-2xl font-bold">{totalArticles}</div>
+          </div>
+        </div>
+        <Link href="/blog" className="text-blue-600 hover:underline text-sm">
+          查看全部文章 →
+        </Link>
+      </div>
+      
+      {/* 搜索和控制栏 */}
+      <div className="flex flex-wrap gap-3 items-center justify-between">
+        <div className="relative w-full md:w-64">
+          <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="搜索标签..."
+            value={searchQuery}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
+            className="w-full pl-8 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+        
+        <div className="flex items-center gap-2">
+          {/* 排序按钮 */}
+          <Button 
+            variant="outline" 
+            size="sm" 
+            className="flex items-center gap-1"
+            onClick={() => setSortMode(sortMode === 'frequency' ? 'name' : 'frequency')}
+          >
+            <ArrowUpDown className="h-4 w-4" />
+            {sortMode === 'frequency' ? '按频率排序' : '按名称排序'}
+          </Button>
+          
+          {/* 视图切换按钮 */}
+          <div className="flex items-center border rounded-md overflow-hidden">
+            <Button 
+              variant={viewMode === 'grid' ? 'default' : 'ghost'} 
+              size="sm"
+              onClick={() => setViewMode('grid')}
+              className="rounded-none"
+            >
+              <Grid className="h-4 w-4" />
+            </Button>
+            <Button 
+              variant={viewMode === 'list' ? 'default' : 'ghost'} 
+              size="sm"
+              onClick={() => setViewMode('list')}
+              className="rounded-none"
+            >
+              <List className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+      
+      {/* 标签显示区域 */}
+      {sortedTags.length === 0 ? (
+        <div className="text-center py-12 text-gray-500">
+          没有找到匹配的标签
+        </div>
+      ) : viewMode === 'grid' ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+          {sortedTags.map(({ tag, count }) => (
+            <Link 
+              key={tag} 
+              href={`/tag/${encodeURIComponent(tag)}`}
+              className={cn(
+                "flex items-center justify-between p-3 rounded-md border transition-all hover:shadow-md",
+                getTagColorClass(count)
+              )}
+            >
+              <span className="font-medium truncate">{tag}</span>
+              <span className="text-xs px-2 py-1 rounded-full bg-white bg-opacity-70">
+                {count}
+              </span>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {sortedTags.map(({ tag, count }) => (
+            <Link 
+              key={tag} 
+              href={`/tag/${encodeURIComponent(tag)}`}
+              className="flex items-center justify-between p-3 rounded-md border border-gray-100 hover:bg-gray-50 transition-colors"
+            >
+              <div className="flex items-center gap-2">
+                <div className={cn(
+                  "w-3 h-3 rounded-full",
+                  count > 5 ? "bg-blue-500" : 
+                  count > 3 ? "bg-blue-300" : 
+                  count > 1 ? "bg-blue-200" : "bg-gray-300"
+                )} />
+                <span>{tag}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-gray-500">{count} 篇文章</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -10,23 +10,10 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
 import { SquareTerminal } from "lucide-react";
-import { config } from "@/lib/config";
 
 export function Header() {
   const pathname = usePathname();
   const isBlogPage = pathname.includes("/blog/");
-
-  const socialLinks = [
-    { title: "Github", key: "github", icon: <GithubIcon /> },
-    { title: "X", key: "x", icon: <XIcon /> },
-    { title: "Xiaohongshu", key: "xiaohongshu", icon: <XiaohongshuIcon /> },
-  ]
-    .map(item => ({
-      title: item.title,
-      href: config.social && config.social[item.key as keyof typeof config.social],
-      icon: item.icon
-    }))
-    .filter(link => !!link.href);
 
   return (
     <header className="pt-4">
@@ -51,11 +38,15 @@ export function Header() {
 
         {/* Right side buttons */}
         <div className="flex items-center space-x-2 md:space-x-8 mr-4">
-          {socialLinks.map((link) => (
-            <Link key={link.title} href={link.href} title={link.title}>
-              {link.icon}
-            </Link>
-          ))}
+          <Link href="https://github.com/guangzhengli" title="Github">
+            <GithubIcon />
+          </Link>
+          <Link href="https://x.com/iguangzhengli" title="X">
+            <XIcon />
+          </Link>
+          <Link href="https://www.xiaohongshu.com/user/profile/6076c9a2000000000101e862" title="Xiaohongshu">
+            <XiaohongshuIcon />
+          </Link>
         </div>
       </motion.div>
     </header >

--- a/src/components/header/nav-desktop-menu.tsx
+++ b/src/components/header/nav-desktop-menu.tsx
@@ -14,13 +14,12 @@ import {
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu"
 import { menuItems } from "./nav-data"
-import { useCategoriesMenu, useTagsMenu } from "./nav-dynamic-menu"
+import { useCategoriesMenu } from "./nav-dynamic-menu"
 import { config } from "@/lib/config"
 
 export function NavDesktopMenu() {
-  // 使用动态生成的分类和标签菜单
+  // 使用动态生成的分类菜单
   const categoriesMenu = useCategoriesMenu();
-  const tagsMenu = useTagsMenu();
   
   // 根据配置过滤要显示的菜单项
   const filteredMenuItems = menuItems.filter(item => {

--- a/src/components/header/nav-desktop-menu.tsx
+++ b/src/components/header/nav-desktop-menu.tsx
@@ -14,39 +14,99 @@ import {
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu"
 import { menuItems } from "./nav-data"
+import { useCategoriesMenu, useTagsMenu } from "./nav-dynamic-menu"
+import { config } from "@/lib/config"
 
 export function NavDesktopMenu() {
+  // 使用动态生成的分类和标签菜单
+  const categoriesMenu = useCategoriesMenu();
+  const tagsMenu = useTagsMenu();
+  
+  // 根据配置过滤要显示的菜单项
+  const filteredMenuItems = menuItems.filter(item => {
+    if (item.title === "分类" && !config.article_category.navbar) {
+      return false;
+    }
+    if (item.title === "标签" && !config.article_tag.navbar) {
+      return false;
+    }
+    return true;
+  });
+  
   return (
     <NavigationMenu>
       <NavigationMenuList>
-        {menuItems.map((item) => (
-          <NavigationMenuItem key={item.title}>
-            {item.submenu ? (
-              <>
+        {/* 基本菜单项 */}
+        {filteredMenuItems.map((item) => {
+          // 如果是分类菜单项，使用动态生成的分类
+          if (item.title === "分类") {
+            return (
+              <NavigationMenuItem key={item.title}>
                 <NavigationMenuTrigger>{item.title}</NavigationMenuTrigger>
                 <NavigationMenuContent>
-                  <ul className="grid h-16 w-[150px] p-2">
-                    {item.submenu.map((subItem) => (
-                      <ListItem
-                        key={subItem.title}
-                        title={subItem.title}
-                        href={subItem.href}
-                      >
-                        {subItem.title}
-                      </ListItem>
-                    ))}
+                  <ul className="grid gap-3 p-4 w-[200px] max-h-[300px] overflow-y-auto">
+                    {categoriesMenu.submenu && categoriesMenu.submenu.length > 0 ? (
+                      categoriesMenu.submenu.map((subItem) => (
+                        <ListItem
+                          key={subItem.title}
+                          title={subItem.title}
+                          href={subItem.href}
+                        >
+                          {subItem.title}
+                        </ListItem>
+                      ))
+                    ) : (
+                      <li className="p-2 text-sm text-gray-500">暂无分类</li>
+                    )}
                   </ul>
                 </NavigationMenuContent>
-              </>
-            ) : (
-              <Link href={item.href ?? ""} title={item.title} legacyBehavior passHref>
-                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
-                  {item.title}
-                </NavigationMenuLink>
-              </Link>
-            )}
-          </NavigationMenuItem>
-        ))}
+              </NavigationMenuItem>
+            );
+          }
+          
+          // 如果是标签菜单项，直接链接到标签页面
+          if (item.title === "标签") {
+            return (
+              <NavigationMenuItem key={item.title}>
+                <Link href={item.href ?? ""} title={item.title} legacyBehavior passHref>
+                  <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                    {item.title}
+                  </NavigationMenuLink>
+                </Link>
+              </NavigationMenuItem>
+            );
+          }
+          
+          // 其他常规菜单项
+          return (
+            <NavigationMenuItem key={item.title}>
+              {item.submenu ? (
+                <>
+                  <NavigationMenuTrigger>{item.title}</NavigationMenuTrigger>
+                  <NavigationMenuContent>
+                    <ul className="grid h-16 w-[150px] p-2">
+                      {item.submenu.map((subItem) => (
+                        <ListItem
+                          key={subItem.title}
+                          title={subItem.title}
+                          href={subItem.href}
+                        >
+                          {subItem.title}
+                        </ListItem>
+                      ))}
+                    </ul>
+                  </NavigationMenuContent>
+                </>
+              ) : (
+                <Link href={item.href ?? ""} title={item.title} legacyBehavior passHref>
+                  <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                    {item.title}
+                  </NavigationMenuLink>
+                </Link>
+              )}
+            </NavigationMenuItem>
+          );
+        })}
       </NavigationMenuList>
     </NavigationMenu>
   )

--- a/src/components/header/nav-dynamic-menu.tsx
+++ b/src/components/header/nav-dynamic-menu.tsx
@@ -10,15 +10,21 @@ export function useCategoriesMenu(): MenuItem {
   
   useEffect(() => {
     const categorySet = new Set<string>()
+    // 分类显示名称映射
+    const categoryDisplayMap: Record<string, string> = {}
     
     allBlogs.forEach((blog: any) => {
       if (blog.category) {
         categorySet.add(blog.category)
+        // 记录分类显示名称
+        if (blog.categoryDisplay) {
+          categoryDisplayMap[blog.category] = blog.categoryDisplay
+        }
       }
     })
     
     const categoryItems = Array.from(categorySet).map(category => ({
-      title: category,
+      title: categoryDisplayMap[category] || category,
       href: `/category/${encodeURIComponent(category)}`
     }))
     

--- a/src/components/header/nav-dynamic-menu.tsx
+++ b/src/components/header/nav-dynamic-menu.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { allBlogs } from "content-collections"
+import { MenuItem } from "./nav-data"
+
+// 获取所有分类
+export function useCategoriesMenu(): MenuItem {
+  const [categories, setCategories] = useState<MenuItem[]>([])
+  
+  useEffect(() => {
+    const categorySet = new Set<string>()
+    
+    allBlogs.forEach((blog: any) => {
+      if (blog.category) {
+        categorySet.add(blog.category)
+      }
+    })
+    
+    const categoryItems = Array.from(categorySet).map(category => ({
+      title: category,
+      href: `/category/${encodeURIComponent(category)}`
+    }))
+    
+    setCategories(categoryItems)
+  }, [])
+  
+  return {
+    title: "分类",
+    href: "#",
+    submenu: categories
+  }
+}
+
+// 获取所有标签
+export function useTagsMenu(): MenuItem {
+  const [tags, setTags] = useState<MenuItem[]>([])
+  
+  useEffect(() => {
+    const tagSet = new Set<string>()
+    
+    allBlogs.forEach((blog: any) => {
+      if (blog.tags && Array.isArray(blog.tags)) {
+        blog.tags.forEach((tag: string) => {
+          tagSet.add(tag)
+        })
+      }
+    })
+    
+    const tagItems = Array.from(tagSet).map(tag => ({
+      title: tag,
+      href: `/tag/${encodeURIComponent(tag)}`
+    }))
+    
+    setTags(tagItems)
+  }, [])
+  
+  return {
+    title: "标签",
+    href: "#",
+    submenu: tags
+  }
+}

--- a/src/components/header/nav-mobile-menu.tsx
+++ b/src/components/header/nav-mobile-menu.tsx
@@ -7,6 +7,8 @@ import {
   Sheet,
   SheetContent,
   SheetTrigger,
+  SheetTitle,
+  SheetHeader,
 } from "@/components/ui/sheet"
 import {
   Collapsible,
@@ -15,6 +17,8 @@ import {
 } from "@/components/ui/collapsible"
 import { cn } from "@/lib/utils"
 import { menuItems, MenuItem } from "./nav-data"
+import { useCategoriesMenu, useTagsMenu } from "./nav-dynamic-menu"
+import { config } from "@/lib/config"
 
 const MenuItemComponent: React.FC<{ item: MenuItem; depth?: number }> = ({ item, depth = 0 }) => {
   const [isOpen, setIsOpen] = React.useState(false)
@@ -64,6 +68,28 @@ const MenuItemComponent: React.FC<{ item: MenuItem; depth?: number }> = ({ item,
 export function NavMobileMenu() {
   const [open, setOpen] = React.useState(false)
 
+  // 使用动态生成的分类和标签菜单
+  const categoriesMenu = useCategoriesMenu();
+  const tagsMenu = useTagsMenu();
+
+  // 创建包含动态菜单的完整菜单项列表
+  const fullMenuItems = menuItems.filter(item => {
+    // 根据配置过滤分类和标签菜单项
+    if (item.title === "分类" && !config.article_category.navbar) {
+      return false;
+    }
+    if (item.title === "标签" && !config.article_tag.navbar) {
+      return false;
+    }
+    return true;
+  }).map(item => {
+    if (item.title === "分类") {
+      return categoriesMenu;
+    }
+    // 标签直接使用原始菜单项，不再生成下拉列表
+    return item;
+  });
+
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>
@@ -73,8 +99,11 @@ export function NavMobileMenu() {
         </Button>
       </SheetTrigger>
       <SheetContent side="left" className="w-[240px] sm:w-[300px]">
-        <nav className="flex flex-col space-y-4 ml-4 mt-4">
-          {menuItems.map((item) => (
+        <SheetHeader>
+          <SheetTitle>导航菜单</SheetTitle>
+        </SheetHeader>
+        <nav className="flex flex-col space-y-4 ml-4">
+          {fullMenuItems.map((item) => (
             <MenuItemComponent key={item.title} item={item} />
           ))}
         </nav>

--- a/src/components/header/nav-mobile-menu.tsx
+++ b/src/components/header/nav-mobile-menu.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/collapsible"
 import { cn } from "@/lib/utils"
 import { menuItems, MenuItem } from "./nav-data"
-import { useCategoriesMenu, useTagsMenu } from "./nav-dynamic-menu"
+import { useCategoriesMenu } from "./nav-dynamic-menu"
 import { config } from "@/lib/config"
 
 const MenuItemComponent: React.FC<{ item: MenuItem; depth?: number }> = ({ item, depth = 0 }) => {
@@ -68,9 +68,8 @@ const MenuItemComponent: React.FC<{ item: MenuItem; depth?: number }> = ({ item,
 export function NavMobileMenu() {
   const [open, setOpen] = React.useState(false)
 
-  // 使用动态生成的分类和标签菜单
+  // 使用动态生成的分类菜单
   const categoriesMenu = useCategoriesMenu();
-  const tagsMenu = useTagsMenu();
 
   // 创建包含动态菜单的完整菜单项列表
   const fullMenuItems = menuItems.filter(item => {

--- a/src/components/mdx-components.tsx
+++ b/src/components/mdx-components.tsx
@@ -148,7 +148,7 @@ const components = {
   pre: ({ className, ...props }: React.HTMLAttributes<HTMLPreElement>) => (
     <pre
       className={cn(
-        "text-[0.8rem] mt-4",
+        "text-[0.8rem]",
         className
       )}
       {...props}
@@ -192,3 +192,4 @@ const components = {
 }
 
 export { components }
+

--- a/src/components/mdx-components.tsx
+++ b/src/components/mdx-components.tsx
@@ -104,7 +104,7 @@ const components = {
     ...props
   }: React.ImgHTMLAttributes<HTMLImageElement>) => (
     // eslint-disable-next-line @next/next/no-img-element
-    <img className={cn("max-w-full rounded-md", className)} alt={alt} {...props} />
+    <img className={cn("max-w-full w-auto h-auto rounded-md", className)} alt={alt} {...props} />
   ),
   hr: ({ ...props }: React.HTMLAttributes<HTMLHRElement>) => (
     <hr className="my-4 md:my-8" {...props} />
@@ -114,7 +114,7 @@ const components = {
       <table
         className={cn(
           "mx-auto mb-12 w-full border-collapse border-spacing-0 text-left",
-          "text-[1.1rem]",
+          "text-sm sm:text-base md:text-[1.1rem]",
           className
         )}
         {...props}
@@ -146,19 +146,21 @@ const components = {
     />
   ),
   pre: ({ className, ...props }: React.HTMLAttributes<HTMLPreElement>) => (
-    <pre
-      className={cn(
-        "text-[0.8rem]",
-        className
-      )}
-      {...props}
-    />
+    <div className="overflow-x-auto my-6">
+      <pre
+        className={cn(
+          "text-[0.8rem] max-w-full",
+          className
+        )}
+        {...props}
+      />
+    </div>
   ),
   code: ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
     <code
       className={cn(
-        "w-max-2xl rounded-[0.6rem] bg-[#ededeb] px-[0.3rem] py-[0.2rem]",
-        "font-mono text-[1.0rem] font-normal text-[#ed4759]",
+        "rounded-[0.6rem] bg-[#ededeb] px-[0.3rem] py-[0.2rem] break-words",
+        "font-mono text-sm md:text-[1.0rem] font-normal text-[#ed4759] overflow-wrap-anywhere",
         className
       )}
       {...props}

--- a/src/components/tag-cloud.tsx
+++ b/src/components/tag-cloud.tsx
@@ -1,0 +1,176 @@
+"use client"
+
+import * as React from 'react'
+import Link from 'next/link'
+import { allBlogs } from 'content-collections'
+import { cn } from '@/lib/utils'
+
+// 计算标签使用频率
+export function getTagsWithFrequency() {
+  const tagFrequency: Record<string, number> = {}
+  
+  allBlogs.forEach((blog: any) => {
+    if (blog.tags && Array.isArray(blog.tags)) {
+      blog.tags.forEach((tag: string) => {
+        tagFrequency[tag] = (tagFrequency[tag] || 0) + 1
+      })
+    }
+  })
+  
+  // 转换为数组并排序
+  const sortedTags = Object.entries(tagFrequency)
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count)
+  
+  return sortedTags
+}
+
+// 标签云组件
+interface TagCloudProps {
+  limit?: number
+  className?: string
+  showCount?: boolean
+  minFontSize?: number
+  maxFontSize?: number
+  customTags?: Array<{tag: string, count: number}>
+  useFixedSize?: boolean
+  fixedSize?: number
+}
+
+export function TagCloud({ 
+  limit, 
+  className, 
+  showCount = false,
+  minFontSize = 12,
+  maxFontSize = 24,
+  customTags,
+  useFixedSize = false,
+  fixedSize = 14
+}: TagCloudProps) {
+  const [tags, setTags] = React.useState<Array<{tag: string, count: number}>>([])  
+  React.useEffect(() => {
+    // 如果提供了自定义标签列表，则使用自定义标签
+    if (customTags) {
+      setTags(limit ? customTags.slice(0, limit) : customTags)
+      return
+    }
+    
+    // 否则使用所有博客文章的标签
+    const allTags = getTagsWithFrequency()
+    setTags(limit ? allTags.slice(0, limit) : allTags)
+  }, [limit, customTags])
+  
+  // 如果没有标签，返回空
+  if (tags.length === 0) {
+    return null
+  }
+  
+  // 计算最大和最小频率
+  const maxCount = Math.max(...tags.map(t => t.count))
+  const minCount = Math.min(...tags.map(t => t.count))
+  
+  // 计算标签字体大小
+  const getFontSize = (count: number) => {
+    // 如果使用固定字体大小，直接返回固定大小
+    if (useFixedSize) return fixedSize
+    
+    if (maxCount === minCount) return (minFontSize + maxFontSize) / 2
+    
+    const size = minFontSize + 
+      ((count - minCount) / (maxCount - minCount)) * (maxFontSize - minFontSize)
+    
+    return Math.round(size)
+  }
+  
+  return (
+    <div className={cn("flex flex-wrap gap-2", className)}>
+      {tags.map(({ tag, count }) => (
+        <Link 
+          key={tag} 
+          href={`/tag/${encodeURIComponent(tag)}`}
+          className="transition-all hover:text-blue-600"
+          style={{ fontSize: `${getFontSize(count)}px` }}
+        >
+          <span className="whitespace-nowrap">
+            {tag}
+            {showCount && <span className="text-gray-500 text-xs ml-1">({count})</span>}
+          </span>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+// 字母索引标签组件
+export function AlphabeticalTagList() {
+  const [groupedTags, setGroupedTags] = React.useState<Record<string, Array<{tag: string, count: number}>>>({})
+  const [letters, setLetters] = React.useState<string[]>([])
+  
+  React.useEffect(() => {
+    const allTags = getTagsWithFrequency()
+    
+    // 按字母分组
+    const grouped: Record<string, Array<{tag: string, count: number}>> = {}
+    
+    allTags.forEach(tagItem => {
+      const firstLetter = tagItem.tag.charAt(0).toUpperCase()
+      if (!grouped[firstLetter]) {
+        grouped[firstLetter] = []
+      }
+      grouped[firstLetter].push(tagItem)
+    })
+    
+    // 对每个字母组内的标签按字母顺序排序
+    Object.keys(grouped).forEach(letter => {
+      grouped[letter].sort((a, b) => a.tag.localeCompare(b.tag))
+    })
+    
+    // 获取所有字母并排序
+    const allLetters = Object.keys(grouped).sort()
+    
+    setGroupedTags(grouped)
+    setLetters(allLetters)
+  }, [])
+  
+  if (letters.length === 0) {
+    return <div className="text-gray-500">暂无标签</div>
+  }
+  
+  return (
+    <div className="space-y-8">
+      {/* 字母索引 */}
+      <div className="flex flex-wrap gap-2 sticky top-0 bg-white py-2 z-10 border-b">
+        {letters.map(letter => (
+          <a 
+            key={letter} 
+            href={`#tag-group-${letter}`}
+            className="w-8 h-8 flex items-center justify-center rounded-full bg-gray-100 hover:bg-gray-200 transition-colors"
+          >
+            {letter}
+          </a>
+        ))}
+      </div>
+      
+      {/* 标签列表 */}
+      <div className="space-y-6">
+        {letters.map(letter => (
+          <div key={letter} id={`tag-group-${letter}`} className="scroll-mt-20">
+            <h3 className="text-xl font-bold mb-3">{letter}</h3>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+              {groupedTags[letter].map(({ tag, count }) => (
+                <Link 
+                  key={tag} 
+                  href={`/tag/${encodeURIComponent(tag)}`}
+                  className="flex items-center justify-between py-1 px-2 rounded hover:bg-gray-100 transition-colors"
+                >
+                  <span>{tag}</span>
+                  <span className="text-sm text-gray-500">({count})</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/content/blog/hello-world.md
+++ b/src/content/blog/hello-world.md
@@ -5,8 +5,10 @@ updated: 2025-04-05T20:10:00+08:00
 keywords: ["hello", "world"]
 featured: true
 summary: "这篇文章包含markdown语法基本的内容。"
-category: "教程"
-tags: ["Markdown", "语法", "入门"]
+category: "tutorial"
+categoryDisplay: "教程"
+tags: ["markdown", "syntax", "beginner"]
+tagsDisplay: ["Markdown", "语法", "入门"]
 ---
 
 这篇文章包含markdown语法基本的内容。

--- a/src/content/blog/hello-world.md
+++ b/src/content/blog/hello-world.md
@@ -5,6 +5,8 @@ updated: 2025-04-05T20:10:00+08:00
 keywords: ["hello", "world"]
 featured: true
 summary: "这篇文章包含markdown语法基本的内容。"
+category: "教程"
+tags: ["Markdown", "语法", "入门"]
 ---
 
 这篇文章包含markdown语法基本的内容。

--- a/src/content/blog/intro.md
+++ b/src/content/blog/intro.md
@@ -5,6 +5,8 @@ updated: 2025-04-05T21:10:00+08:00
 keywords: ["hello", "world"]
 featured: true
 summary: "这是一个 Nextjs 博客模板，本文会介绍这个模板的一些基本用法"
+category: "指南"
+tags: ["Next.js", "博客", "模板"]
 ---
 
 这是一个 Nextjs 博客模板，本文会介绍这个模板的一些基本用法。

--- a/src/content/blog/intro.md
+++ b/src/content/blog/intro.md
@@ -5,8 +5,10 @@ updated: 2025-04-05T21:10:00+08:00
 keywords: ["hello", "world"]
 featured: true
 summary: "这是一个 Nextjs 博客模板，本文会介绍这个模板的一些基本用法"
-category: "指南"
-tags: ["Next.js", "博客", "模板"]
+category: "guide"
+categoryDisplay: "指南"
+tags: ["nextjs", "blog", "template"]
+tagsDisplay: ["Next.js", "博客", "模板"]
 ---
 
 这是一个 Nextjs 博客模板，本文会介绍这个模板的一些基本用法。

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -29,6 +29,16 @@ export const config = {
     email: "your.email@example.com",
     bio: "这是一个 Nextjs 博客模板",
   },
+  // 文章分类显示控制
+  article_category: {
+    navbar: true,  // 在导航栏中显示分类
+    sidebar: true, // 在侧边栏中显示分类
+  },
+  // 文章标签显示控制
+  article_tag: {
+    navbar: true,  // 在导航栏中显示标签
+    sidebar: true, // 在侧边栏中显示标签
+  },
   social: {
     github: "https://github.com/xxx",
     x: "https://x.com/xxx",
@@ -46,6 +56,17 @@ export const config = {
       { 
         title: "文章", 
         href: "/blog",
+      },
+      {
+        title: "分类",
+        href: "#",
+        submenu: [
+          // 这里会动态生成分类菜单项
+        ]
+      },
+      {
+        title: "标签", 
+        href: "/tag",
       },
     ],
   },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,12 +8,3 @@ export function cn(...inputs: ClassValue[]) {
 export function absoluteUrl(path: string) {
   return `${process.env.NEXT_PUBLIC_APP_URL}${path}`
 }
-
-export function formatDate(date: string) {
-  const [year, month, day] = new Date(date).toLocaleDateString('zh-CN', {
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric'
-  }).split('/');
-  return `${year}年${month}月${day}日`;
-}


### PR DESCRIPTION
1. 支持分类/标签。
![image](https://github.com/user-attachments/assets/22dc81ec-82fc-41b1-80a8-43fb9df1e7af)

2.用户按需配置是否支持显示标签与分类。在lib/config.ts中添加配置：
```typescript
  // 文章分类显示控制
  article_category: {
    navbar: true,  // 在导航栏中显示分类
    sidebar: true, // 在侧边栏中显示分类
  },
  // 文章标签显示控制
  article_tag: {
    navbar: true,  // 在导航栏中显示标签
    sidebar: true, // 在侧边栏中显示标签
  },
```
设置为false时不显示，设置为true才显示分类与标签。
![image](https://github.com/user-attachments/assets/d9c6a499-6831-430b-8b62-de3022ca4b4c)

3. 标签页支持搜索
![image](https://github.com/user-attachments/assets/e853fe48-859d-49c8-8e8e-c17f12edf65f)

4. 另外由于Cloudflare pages不支持中文路由，所以改造了路由方式，路由全部设置为英文，页面显示分类与标签根据用户添加的元数据显示。
```
如， hello-word.md文档中的元数据添加category，categoryDisplay，tags和tagsDisplay字段：
---
title: Markdown 基本用法
date: 2025-04-05T20:10:00+08:00
updated: 2025-04-05T20:10:00+08:00
keywords: ["hello", "world"]
featured: true
summary: "这篇文章包含markdown语法基本的内容。"
category: "tutorial"
categoryDisplay: "教程"
tags: ["markdown", "syntax", "beginner"]
tagsDisplay: ["Markdown", "语法", "入门"]
---
其中，category与tags是用于路由的路径，categoryDisplay和tagsDisplay字段是页面显示的。
```


