### PR TITLE
支持设置并替换网站logo

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -9,7 +9,7 @@ import XIcon from "@/components/icons/x";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
-import { SquareTerminal } from "lucide-react";
+import { Logo } from "@/components/logo";
 import { config } from "@/lib/config";
 
 export function Header() {
@@ -41,7 +41,7 @@ export function Header() {
 
         {/* Logo */}
         <Link href="/" title="Home" className="flex items-center gap-4 md:order-first">
-          <SquareTerminal className="w-10 h-10" />
+        <Logo />
         </Link>
 
         {/* Desktop navigation */}

--- a/src/components/header/logo.tsx
+++ b/src/components/header/logo.tsx
@@ -1,0 +1,88 @@
+import Image from "next/image";
+import { config } from "@/lib/config";
+import * as LucideIcons from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface LogoProps {
+    className?: string;
+}
+
+export function Logo({ className }: LogoProps) {
+    const logoConfig = config.site.logo;
+    // 移除可能影响尺寸的 className，只保留非尺寸相关的样式
+    const filteredClassName = className?.replace(/\b(w-\w+|h-\w+|size-\w+)\b/g, '').trim();
+    const logoClassName = cn("flex-shrink-0", filteredClassName);
+
+    // 直接使用配置中的尺寸
+    const displayWidth = logoConfig.width;
+    const displayHeight = logoConfig.height;
+
+    switch (logoConfig.type) {
+        case "icon": {
+            // 动态获取 Lucide 图标组件
+            const IconComponent = (LucideIcons as any)[logoConfig.icon];
+
+            if (!IconComponent) {
+                console.warn(`Lucide icon "${logoConfig.icon}" not found, falling back to SquareTerminal`);
+                const FallbackIcon = LucideIcons.SquareTerminal;
+                return (
+                    <FallbackIcon
+                        className={logoClassName}
+                        style={{ width: displayWidth, height: displayHeight }}
+                    />
+                );
+            }
+
+            return (
+                <IconComponent
+                    className={logoClassName}
+                    style={{ width: displayWidth, height: displayHeight }}
+                />
+            );
+        }
+
+        case "svg":
+            return (
+                <div
+                    className={logoClassName}
+                    style={{ width: displayWidth, height: displayHeight }}
+                >
+                    <object
+                        data={logoConfig.svg}
+                        type="image/svg+xml"
+                        width={displayWidth}
+                        height={displayHeight}
+                        aria-label={logoConfig.alt}
+                        className="w-full h-full"
+                    >
+                        {/* SVG 加载失败时的后备方案 */}
+                        <LucideIcons.SquareTerminal
+                            className="w-full h-full"
+                        />
+                    </object>
+                </div>
+            );
+
+        case "img":
+            return (
+                <Image
+                    src={logoConfig.img}
+                    alt={logoConfig.alt}
+                    width={logoConfig.width}
+                    height={logoConfig.height}
+                    className={logoClassName}
+                    style={{ width: displayWidth, height: displayHeight }}
+                    priority
+                />
+            );
+
+        default:
+            // 默认后备方案
+            return (
+                <LucideIcons.SquareTerminal
+                    className={logoClassName}
+                    style={{ width: displayWidth, height: displayHeight }}
+                />
+            );
+    }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,6 +13,15 @@ export const config = {
       svg: "/favicon.svg",
       appleTouchIcon: "/favicon.png",
     },
+    logo: {
+      type: "img", // icon: 使用 Lucide 图标, svg: 使用 SVG 文件, img: 使用图片文件
+      icon: "SquareTerminal", // 当 type 为 "icon" 时使用的 Lucide 图标名称
+      svg: "/logo.svg", // 当 type 为 "svg" 时使用的 SVG 文件路径
+      img: "/favicon.png", // 当 type 为 "img" 时使用的图片文件路径
+      alt: "wangxiaotao's blog", // 图片的 alt 文本
+      width: 100, // logo 宽度
+      height: 100, // logo 高度
+    },
     manifest: "/site.webmanifest",
     rss: {
       title: "Nextjs Blog Template",
@@ -43,8 +52,8 @@ export const config = {
   },
   navigation: {
     main: [
-      { 
-        title: "文章", 
+      {
+        title: "文章",
         href: "/blog",
       },
     ],
@@ -52,7 +61,7 @@ export const config = {
   seo: {
     metadataBase: new URL("https://xxx.com"),
     alternates: {
-      canonical: './',
+      canonical: "./",
     },
     openGraph: {
       type: "website" as const,


### PR DESCRIPTION
1. 功能概述
添加可配置的网站 Logo 支持，允许用户通过配置文件灵活设置网站 Logo，支持多种格式和自定义尺寸。

2. 用户按需配置 Logo 类型和样式
在 lib/config.ts 中添加 logo 配置：
~~~
logo: {
  type: "img", // 支持三种类型：icon(Lucide图标) | svg(SVG文件) | img(图片文件)
  icon: "SquareTerminal", // 当 type 为 "icon" 时使用的 Lucide 图标名称
  svg: "/logo.svg", // 当 type 为 "svg" 时使用的 SVG 文件路径
  img: "/favicon.png", // 当 type 为 "img" 时使用的图片文件路径
  alt: "wangxiaotao's blog", // 图片的 alt 文本
  width: 40, // logo 宽度（像素）
  height: 40, // logo 高度（像素）
},
~~~
用户可以根据需求选择不同的 Logo 类型：
* 设置 type: "icon" 使用 Lucide 图标库中的图标
* 设置 type: "svg" 使用自定义 SVG 文件
* 设置 type: "img" 使用图片文件（PNG、JPG 等）

3.修改的文件：
`src/lib/config.ts` - 添加了 logo 配置
`src/components/header/index.tsx` - 更新使用新的 Logo 组件
`src/components/logo.tsx` - 新创建的 Logo 组件
